### PR TITLE
Move scripts to separate files + cleanup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
   # accessing "localhost:8080" will access port 80 on the guest machine.
 
   config.vm.network "forwarded_port", guest: 9000, host: 9000
-  config.vm.network "forwarded_port", guest: 8080, host: 8080
+  config.vm.network "forwarded_port", guest: 8080, host: 8081
   config.vm.network "forwarded_port", guest: 5050, host: 5050
   config.vm.network "forwarded_port", guest: 5051, host: 5051
   config.vm.network "forwarded_port", guest: 8500, host: 8500
@@ -80,60 +80,7 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
-    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-    echo "deb http://repos.mesosphere.io/debian jessie main" > /etc/apt/sources.list.d/mesosphere.list
-    echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+  config.vm.provision "shell", path: "provision/install.sh"
 
-    apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list
-
-    apt-get update
-    apt-get upgrade -y
-    apt-get install -y marathon mesos python2.7 python-virtualenv
-    apt-get install -y supervisor
-    apt-get install -y docker-engine
-    apt-get install -y nginx
-    apt-get install -y python-pip
-    apt-get install -y python-dev
-    apt-get install -y unzip
-    apt-get install -y curl jq
-    pip install "pyasn1>=0.1.8"
-    pip install consular
-
-    mkdir -p /tmp/consul
-    mkdir -p /usr/share/consul
-
-    wget -P /tmp/consul -qc https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
-    unzip -d /tmp/consul/ /tmp/consul/consul_0.5.2_linux_amd64.zip
-    mv /tmp/consul/consul /usr/local/bin/consul
-
-    wget -P /tmp/consul -qc https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_web_ui.zip
-    unzip -d /tmp/consul/ /tmp/consul/consul_0.5.2_web_ui.zip
-    mv /tmp/consul/dist /usr/share/consul/ui
-
-    wget -P /tmp/consul -qc https://releases.hashicorp.com/consul-template/0.11.1/consul-template_0.11.1_linux_amd64.zip
-    unzip -d /tmp/consul/ /tmp/consul/consul-template_0.11.1_linux_amd64.zip
-    mv /tmp/consul/consul-template /usr/local/bin/consul-template
-    rm -rf /tmp/consul
-
-    usermod -aG docker vagrant
-  SHELL
-
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
-    service zookeeper stop
-    update-rc.d -f zookeeper remove
-    service zookeeper restart
-
-    service mesos-master stop
-    update-rc.d -f mesos-master remove
-    service mesos-master restart
-    service marathon restart
-
-    service mesos-slave stop
-    update-rc.d -f mesos-slave remove
-    service mesos-slave restart
-
-    supervisorctl reload
-  SHELL
+  config.vm.provision "shell", run: "always", path: "provision/restart-services.sh"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
   # accessing "localhost:8080" will access port 80 on the guest machine.
 
   config.vm.network "forwarded_port", guest: 9000, host: 9000
-  config.vm.network "forwarded_port", guest: 8080, host: 8081
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 5050, host: 5050
   config.vm.network "forwarded_port", guest: 5051, host: 5051
   config.vm.network "forwarded_port", guest: 8500, host: 8500

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -10,8 +10,12 @@ echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sourc
 
 apt-get update
 apt-get upgrade -y
-apt-get install -y marathon mesos python2.7 python-virtualenv
-apt-get install -y supervisor
+
+apt-get install -y python2.7 python-virtualenv
+# Tell dpkg not to overwrite our config files
+apt-get install -y -o Dpkg::Options::="--force-confold" marathon mesos
+apt-get install -y -o Dpkg::Options::="--force-confold" supervisor
+
 apt-get install -y docker-engine
 apt-get install -y nginx
 apt-get install -y python-pip

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -1,30 +1,50 @@
 #!/bin/bash -e
 set -x
 
+# Mesosphere repo for Mesos and Marathon
 apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
 echo "deb http://repos.mesosphere.io/debian jessie main" > /etc/apt/sources.list.d/mesosphere.list
-echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
 
+# Docker repo
 apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list
 
+# Backports for OpenJDK 8 for Marathon 0.11+
+echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+
+# Upgrade the system
 apt-get update
 apt-get upgrade -y
 
-apt-get install -y python2.7 python-virtualenv
-# Tell dpkg not to overwrite our config files
-apt-get install -y -o Dpkg::Options::="--force-confold" marathon mesos
-apt-get install -y -o Dpkg::Options::="--force-confold" supervisor
+# Install python things
+apt-get install -y \
+    python2.7 \
+    python-dev \
+    python-pip \
+    python-virtualenv
 
-apt-get install -y docker-engine
-apt-get install -y nginx
-apt-get install -y python-pip
-apt-get install -y python-dev
-apt-get install -y unzip
-apt-get install -y curl jq
+# Tell dpkg not to overwrite our config files when installing mesos, marathon and supervisor
+apt-get install -y -o Dpkg::Options::="--force-confold" \
+    marathon \
+    mesos \
+    supervisor
+
+# Install docker and nginx
+apt-get install -y \
+    docker-engine \
+    nginx \
+    unzip
+
+# Curl and jq are useful to have
+apt-get install -y \
+    curl \
+    jq
+
+# Install consular
 pip install "pyasn1>=0.1.8"
 pip install consular
 
+# Install consul and consul-template
 mkdir -p /tmp/consul
 mkdir -p /usr/share/consul
 
@@ -41,4 +61,5 @@ unzip -d /tmp/consul/ /tmp/consul/consul-template_0.11.1_linux_amd64.zip
 mv /tmp/consul/consul-template /usr/local/bin/consul-template
 rm -rf /tmp/consul
 
+# Add the vagrant user to the docker group so that the docker commands can be used without sudo
 usermod -aG docker vagrant

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+set -x
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+echo "deb http://repos.mesosphere.io/debian jessie main" > /etc/apt/sources.list.d/mesosphere.list
+echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+
+apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list
+
+apt-get update
+apt-get upgrade -y
+apt-get install -y marathon mesos python2.7 python-virtualenv
+apt-get install -y supervisor
+apt-get install -y docker-engine
+apt-get install -y nginx
+apt-get install -y python-pip
+apt-get install -y python-dev
+apt-get install -y unzip
+apt-get install -y curl jq
+pip install "pyasn1>=0.1.8"
+pip install consular
+
+mkdir -p /tmp/consul
+mkdir -p /usr/share/consul
+
+wget -P /tmp/consul -qc https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
+unzip -d /tmp/consul/ /tmp/consul/consul_0.5.2_linux_amd64.zip
+mv /tmp/consul/consul /usr/local/bin/consul
+
+wget -P /tmp/consul -qc https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_web_ui.zip
+unzip -d /tmp/consul/ /tmp/consul/consul_0.5.2_web_ui.zip
+mv /tmp/consul/dist /usr/share/consul/ui
+
+wget -P /tmp/consul -qc https://releases.hashicorp.com/consul-template/0.11.1/consul-template_0.11.1_linux_amd64.zip
+unzip -d /tmp/consul/ /tmp/consul/consul-template_0.11.1_linux_amd64.zip
+mv /tmp/consul/consul-template /usr/local/bin/consul-template
+rm -rf /tmp/consul
+
+usermod -aG docker vagrant

--- a/provision/restart-services.sh
+++ b/provision/restart-services.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+set -x
+
+service zookeeper stop
+update-rc.d -f zookeeper remove
+service zookeeper restart
+
+service mesos-master stop
+update-rc.d -f mesos-master remove
+service mesos-master restart
+service marathon restart
+
+service mesos-slave stop
+update-rc.d -f mesos-slave remove
+service mesos-slave restart
+
+supervisorctl reload


### PR DESCRIPTION
- Move scripts to `provision/`.
- Clean up, add comments, group apt-get operations
- Fix `dpkg --configure` failing for mesos + supervisor due to already present config files
