### PR TITLE
Share a directory that is not the seed-stack repo

### DIFF
--- a/share/.gitignore
+++ b/share/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in the directory except the README
+*
+!README.md
+!.gitignore

--- a/share/README.md
+++ b/share/README.md
@@ -1,2 +1,2 @@
 ## Vagrant share directory
-To share files between the host and the guest, place them in this directory. The files can be accessed on the host at `/vagrant/share`.
+To share files between the host and the guest, place them in this directory. The files can be accessed on the guest at `/vagrant/share`.

--- a/share/README.md
+++ b/share/README.md
@@ -1,0 +1,2 @@
+## Vagrant share directory
+To share files between the host and the guest, place them in this directory. The files can be accessed on the host at `/vagrant/share`.


### PR DESCRIPTION
Most people will clone this repo and do a `vagrant up`

By default, Vagrant shares the directory containing the Vagrantfile on the guest at `/vagrant`. It's useful to put stuff in there.

If `/vagrant` is the seed-stack repo on the host a bunch of things get tracked by git that shouldn't when a user shares files between guest and host.
