### PR TITLE
Set up docker DNS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", path: "provision/install.sh"
+  config.vm.provision "shell", path: "provision/consul-dns.sh"
 
   config.vm.provision "shell", run: "always", path: "provision/restart-services.sh"
 end

--- a/provision/consul-dns.sh
+++ b/provision/consul-dns.sh
@@ -4,11 +4,8 @@ set -x
 # Get Dnsmasq to forward all DNS queries ending in 'consul' to Consul
 NAMESERVER='10.0.2.3' # VirtualBox DNS
 
-apt-get purge -y resolv-conf
 apt-get install -y dnsmasq
 
-# TODO: Not lose the auto-configured search
-echo "nameserver 127.0.0.1" > /etc/resolv.conf
 echo "nameserver $NAMESERVER" >  /etc/resolv.primary
 echo "resolv-file=/etc/resolv.primary" > /etc/dnsmasq.conf
 echo "server=/consul/127.0.0.1#8600" > /etc/dnsmasq.d/consul

--- a/provision/consul-dns.sh
+++ b/provision/consul-dns.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+set -x
+
+# Get Dnsmasq to forward all DNS queries ending in 'consul' to Consul
+NAMESERVER='10.0.2.3' # VirtualBox DNS
+
+apt-get purge -y resolv-conf
+apt-get install -y dnsmasq
+
+# TODO: Not lose the auto-configured search
+echo "nameserver 127.0.0.1" > /etc/resolv.conf
+echo "nameserver $NAMESERVER" >  /etc/resolv.primary
+echo "resolv-file=/etc/resolv.primary" > /etc/dnsmasq.conf
+echo "server=/consul/127.0.0.1#8600" > /etc/dnsmasq.d/consul
+service dnsmasq restart
+
+# Make Docker containers use the host for DNS queries
+DOCKER0_IP="$(ip addr show dev docker0 | grep -o 'inet [0-9.]\+' | cut -c6-)"
+echo "DOCKER_OPTS=\"--dns $DOCKER0_IP\"" >> /etc/default/docker
+service docker restart

--- a/provision/consul-dns.sh
+++ b/provision/consul-dns.sh
@@ -7,7 +7,7 @@ NAMESERVER='10.0.2.3' # VirtualBox DNS
 apt-get install -y dnsmasq
 
 echo "nameserver $NAMESERVER" >  /etc/resolv.primary
-echo "resolv-file=/etc/resolv.primary" > /etc/dnsmasq.conf
+echo -e "resolv-file=/etc/resolv.primary\ncache-size=0" > /etc/dnsmasq.conf
 echo "server=/consul/127.0.0.1#8600" > /etc/dnsmasq.d/consul
 service dnsmasq restart
 

--- a/provision/consul-dns.sh
+++ b/provision/consul-dns.sh
@@ -13,5 +13,5 @@ service dnsmasq restart
 
 # Make Docker containers use the host for DNS queries
 DOCKER0_IP="$(ip addr show dev docker0 | grep -o 'inet [0-9.]\+' | cut -c6-)"
-echo "DOCKER_OPTS=\"--dns $DOCKER0_IP\"" >> /etc/default/docker
+echo "DOCKER_OPTS=\"--dns $DOCKER0_IP\"" > /etc/default/docker
 service docker restart


### PR DESCRIPTION
DNSmasq + some docker daemon config is needed for containers to look up services via Consul DNS.

(Not currently used for unicore but needed elsewhere)
