### PR TITLE
Make provisioning idempotent

### DIFF
--- a/provision/install.sh
+++ b/provision/install.sh
@@ -59,6 +59,9 @@ mv /tmp/consul/consul /usr/local/bin/consul
 
 wget -P /tmp/consul -qc https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_web_ui.zip
 unzip -d /tmp/consul/ /tmp/consul/consul_0.5.2_web_ui.zip
+if [ -d /usr/share/consul/ui ]; then
+    rm -rf /usr/share/consul/ui
+fi
 mv /tmp/consul/dist /usr/share/consul/ui
 
 wget -P /tmp/consul -qc https://releases.hashicorp.com/consul-template/0.11.1/consul-template_0.11.1_linux_amd64.zip


### PR DESCRIPTION
Currently it breaks on trying to move consul's ui to `/usr/share/consul/ui` because stuff already exists there.
