### PR TITLE
mesos-master doesn't come up on boot.

### DIFF
--- a/provision/install.sh
+++ b/provision/install.sh
@@ -33,6 +33,8 @@ apt-get install -y -o Dpkg::Options::="--force-confold" \
     marathon \
     mesos \
     supervisor
+rm /etc/mesos-master/*.dpkg-dist
+rm /etc/supervisor/*.dpkg-dist
 
 # Install docker and nginx
 apt-get install -y \


### PR DESCRIPTION
```
==> default: Running provisioner: shell...
    default: Running: /var/folders/74/2zztc5lj035c2xsr5tn1c2kc0000gn/T/vagrant-shell20151104-12167-1ukes5f.sh
==> default: stdin: is not a tty
==> default: + service zookeeper restart
==> default: zookeeper stop/waiting
==> default: zookeeper start/running, process 1705
==> default: + service mesos-master restart
==> default: stop: Unknown instance:
==> default: mesos-master start/running, process 1715
==> default: + service marathon restart
==> default: marathon stop/waiting
==> default: marathon start/running, process 1745
==> default: + service mesos-slave restart
==> default: stop: Unknown instance:
==> default: mesos-slave start/running, process 1764
==> default: + service supervisor restart
==> default: Restarting supervisor:
==> default: supervisord.
```

Marathon's happy on 8080 and the mesos-slave process is running, the master however isn't.
