### PR TITLE
Host services stored in Consul not accessible from containers

### DIFF
--- a/etc/consul.d/server/config.json
+++ b/etc/consul.d/server/config.json
@@ -5,8 +5,8 @@
     "ui_dir": "/usr/share/consul/ui",
     "log_level": "INFO",
     "enable_syslog": true,
-    "advertise_addr": "127.0.0.1",
-    "client_addr": "127.0.0.1",
+    "advertise_addr": "10.0.2.15",
+    "client_addr": "0.0.0.0",
     "services": [{
         "name": "marathon",
         "port": 8080


### PR DESCRIPTION
We have Consul configured to use a `advertise_addr` of `127.0.0.1`. This means that if we had simple Consul service definitions for applications on the host (postgres, redis, etc), DNS lookups to those services will return `127.0.0.1`. This is ok on the host as `127.0.0.1` is the correct address for locally running services, but from a container, `127.0.0.1` is the local interface of the container, not the host. On production servers we set the `advertise_addr` to the address of `eth0` or `eth1`, so containers can access services on hosts via those addresses.

("Host" above refers to the Vagrant machine, i.e. the guest VM).

We could possibly set the `advertise_addr` to the `eth0` interface IP. I'm not entirely sure what the effects of this are, though.
