### PR TITLE
Faster setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,10 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-14.04"
+  config.vm.box = "ubuntu/trusty64"
+
+  # Give our box a name, because "default" is confusing.
+  config.vm.define "seed-stack"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -1,10 +1,26 @@
 #!/bin/bash -e
 set -x
 
-# Upgrade the system
+# Add all the extra repos we'll need to avoid unnecessary `apt-get update` runs.
+
+# Web Upd8 PPA for Oracle Java 8 for Marathon 0.11+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7B2C3B0889BF5709A105D03AC2518248EEA14886
+echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java-trusty.list
+
+# Docker repo
+apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
+
+# Mesosphere repo for Mesos and Marathon
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E56151BF
+echo "deb http://repos.mesosphere.io/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
+
 apt-get update
-# FIXME: see issue #21
-#apt-get upgrade -y
+# No need to upgrade. We assume we're using a recent base image and this is a
+# local test stack where being a little behind on security updates isn't the
+# end of the world.
+
+# Install the things we want/need.
 
 /vagrant/provision/install/python.sh
 /vagrant/provision/install/java8.sh

--- a/provision/install/docker.sh
+++ b/provision/install/docker.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -e
 set -x
 
-# Docker repo
-apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
-apt-get update
+# We do this in install.sh to avoid unnecessary `apt-get update` runs.
+
+# # Docker repo
+# apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+# echo "deb http://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
+# apt-get update
 
 apt-get install -y docker-engine
 

--- a/provision/install/java8.sh
+++ b/provision/install/java8.sh
@@ -1,9 +1,11 @@
 #!/bin/sh -eux
 
-# Web Upd8 PPA for Oracle Java 8 for Marathon 0.11+
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7B2C3B0889BF5709A105D03AC2518248EEA14886
-echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java-trusty.list
-apt-get update
+# We do this in install.sh to avoid unnecessary `apt-get update` runs.
+
+# # Web Upd8 PPA for Oracle Java 8 for Marathon 0.11+
+# apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7B2C3B0889BF5709A105D03AC2518248EEA14886
+# echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java-trusty.list
+# apt-get update
 
 # Install Java 8 after accepting the license agreement
 echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | /usr/bin/debconf-set-selections

--- a/provision/install/marathon.sh
+++ b/provision/install/marathon.sh
@@ -3,10 +3,12 @@ set -x
 
 # DEPENDENCIES: python, java8
 
-# Mesosphere repo for Mesos and Marathon
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E56151BF
-echo "deb http://repos.mesosphere.io/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
-apt-get update
+# We do this in install.sh to avoid unnecessary `apt-get update` runs.
+
+# # Mesosphere repo for Mesos and Marathon
+# apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E56151BF
+# echo "deb http://repos.mesosphere.io/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list
+# apt-get update
 
 # Install mesos/marathon
 apt-get install -y \


### PR DESCRIPTION
This branch improves the VM setup in the following ways:
- It uses the `ubuntu/trusty64` box which is smaller than the previous one and is also updated regularly.
- It sets a better name than `default`.
- Extra apt repos are added at the start of the provisioning process to avoid unnecessary (and slow) `apt-get update` runs.
