### PR TITLE
Add seed_stack module

### DIFF
--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -6,6 +6,7 @@ mod 'puppetlabs/concat', '1.2.5'
 mod 'stahnma/epel', '1.2.2'
 mod 'nanliu/staging', '1.0.3'
 mod 'puppetlabs/stdlib', '4.10.0'
+mod 'richardc/datacat', '0.6.2'
 
 # 3rd party modules
 mod 'camptocamp/openssl', '1.5.1'
@@ -14,3 +15,4 @@ mod 'garethr/docker', '4.1.1'
 mod 'gdhbashton/consul_template', '0.2.4'
 mod 'KyleAnderson/consul', '1.0.4'
 mod 'stankevich/python', '1.10.0'
+mod 'deric/zookeeper', '0.4.1'

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -17,6 +17,7 @@ The following 3rd party modules (and their dependencies) are installed:
 * [gdhbashton/consul_template](https://forge.puppetlabs.com/gdhbashton/consul_template)
 * [KyleAnderson/consul](https://forge.puppetlabs.com/KyleAnderson/consul)
 * [stankevich/python](https://forge.puppetlabs.com/stankevich/python)
+* [deric/zookeeper](https://forge.puppetlabs.com/deric/zookeeper)
 
 ### Travis tests
 The Puppet configuration has a few tests run on it using [Travis CI](https://travis-ci.org/praekelt/seed-stack). You can run the same tests as Travis on your local machine with the following commands (first making sure that you have Ruby **1.9.3** and [Bundler](http://bundler.io) installed):

--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -1,19 +1,5 @@
 node default {
 
-  $docker_ensure = '1.9.1*'
-  $mesos_ensure = '0.24.1*'
-  $marathon_ensure = '0.13.0*'
-  $consul_version = '0.6.0'
-  $consul_template_version = '0.12.0'
-
-  include oracle_java
-
-  class { 'docker':
-    ensure => $docker_ensure,
-    dns => $ipaddress_docker0,
-    docker_users => ['vagrant'],
-  }
-
   # NOTE: This cert wrangling is only good for a single machine. We need some
   # other mechanism to get our certs to the right place in a multi-node setup.
   package { 'openssl': }
@@ -38,97 +24,20 @@ node default {
     notify => [Service['docker']],
   }
 
-  # We need this because mesos::install doesn't wait for apt::update before
-  # trying to install the package.
-  Class['apt::update'] -> Package['mesos']
-
-  $mesos_zk = 'zk://localhost:2181/mesos'
-
-  class { 'mesos':
-    ensure => $mesos_ensure,
-    repo => 'mesosphere',
-    zookeeper => $mesos_zk,
-    require => Class['oracle_java'],
-  }
-
-  class { 'mesos::master':
-    options => {
-      hostname => 'localhost',
-      quorum => 1,
-    },
-  }
-
-  class { 'mesos::slave':
-    resources => {
-      'ports(*)' => '[10000-10050]',
-    },
-    options => {
-      hostname => 'localhost',
-      containerizers => 'docker,mesos',
-      executor_registration_timeout => '5mins',
-    },
-  }
-
-  class { 'marathon':
-    ensure => $marathon_ensure,
-    zookeeper => 'zk://localhost:2181/marathon',
-    master => $mesos_zk,
-    options => {
-      hostname => 'localhost',
-      event_subscriber => 'http_callback',
-    },
-    require => Class['oracle_java'],
-  }
-
   package { 'unzip':
     ensure => installed,
   }
 
-  class { 'consul':
-    version => $consul_version,
-    config_hash => {
-      'bootstrap_expect' => 1,
-      'server'           => true,
-      'data_dir'         => '/var/consul',
-      'ui_dir'           => '/var/consul/ui',
-      'log_level'        => 'INFO',
-      'enable_syslog'    => true,
-      'advertise_addr'   => $ipaddress_eth0,
-      'client_addr'      => '0.0.0.0',
-      'domain'           => 'consul.',
-    },
-    services => {
-      'marathon'        => { port => 8080 },
-      'mesos'           => { port => 5050 },
-      'zookeeper'       => { port => 2181 },
-      'docker-registry' => { port => 5000 },
-    },
-    require => Package['unzip']
+  include seed_stack::controller
+  class { 'seed_stack::worker':
+    controller => true,
   }
 
-  class { 'consul_template':
-    version          => $consul_template_version,
-    config_dir       => '/etc/consul-template',
-    user             => 'root',
-    group            => 'root',
-    consul_host      => '127.0.0.1',
-    consul_port      => 8500,
-    consul_retry     => '10s',
-    # For some reason, consul-template doesn't like this option.
-    # consul_max_stale => '10m',
-    log_level        => 'warn',
-    require => Package['unzip']
-  }
-
-  file { '/etc/consul-template/nginx-upstreams.ctmpl':
-    source => 'puppet:///modules/consular/nginx-upstreams.ctmpl',
-  }
-  ~>
-  consul_template::watch { 'nginx-upstreams':
-    source      => '/etc/consul-template/nginx-upstreams.ctmpl',
-    destination => '/etc/nginx/sites-enabled/seed-upstreams.conf',
-    command     => '/etc/init.d/nginx reload',
-  }
+  # Ensure that Oracle Java 8 is installed before Java is installed as a dependency
+  include oracle_java
+  Package['oracle-java8-installer'] -> Package['marathon']
+  Package['oracle-java8-installer'] -> Package['mesos']
+  Package['oracle-java8-installer'] -> Package['zookeeper']
 
   file { '/etc/consul-template/nginx-websites.ctmpl':
     source => 'puppet:///modules/consular/nginx-websites.ctmpl',
@@ -138,39 +47,7 @@ node default {
     source      => '/etc/consul-template/nginx-websites.ctmpl',
     destination => '/etc/nginx/sites-enabled/seed-websites.conf',
     command     => '/etc/init.d/nginx reload',
-  }
-
-  file { '/etc/consul-template/nginx-services.ctmpl':
-    source => 'puppet:///modules/consular/nginx-services.ctmpl',
-  }
-  ~>
-  consul_template::watch { 'nginx-services':
-    source      => '/etc/consul-template/nginx-services.ctmpl',
-    destination => '/etc/nginx/sites-enabled/seed-services.conf',
-    command     => '/etc/init.d/nginx reload',
-  }
-
-  package { 'nginx-light': }
-  ~>
-  service { 'nginx': }
-
-  package { 'dnsmasq': }
-  ~>
-  file { '/etc/dnsmasq.d/consul':
-    content => "cache-size=0\nserver=/consul/127.0.0.1#8600",
-  }
-  ~>
-  service { 'dnsmasq': }
-
-  class { 'consular':
-    consular_args => [
-      '--host=localhost',
-      '--sync-interval=300',
-      '--purge',
-      '--registration-id=localhost',
-      '--consul=http://localhost:8500',
-      '--marathon=http://localhost:8080',
-    ],
+    require     => Service['nginx'],
   }
 
   docker::run { 'registry':

--- a/puppet/modules/consular/manifests/init.pp
+++ b/puppet/modules/consular/manifests/init.pp
@@ -1,4 +1,5 @@
 class consular(
+  $ensure        = 'installed',
   $consular_args = [],
 ) {
   # NOTE: This is a temporary PPA that is managed manually by a single
@@ -11,7 +12,7 @@ class consular(
   }
   ~>
   package { 'python-consular':
-    ensure => 'latest',
+    ensure => $ensure,
     require => Class['apt::update'],
   }
   ~>

--- a/puppet/modules/seed_stack/manifests/controller.pp
+++ b/puppet/modules/seed_stack/manifests/controller.pp
@@ -107,7 +107,7 @@ class seed_stack::controller (
     config_hash => {
       'server'           => true,
       'bootstrap_expect' => size($controller_addresses),
-      'join'             => delete($controller_addresses, $address),
+      'retry_join'       => delete($controller_addresses, $address),
       'data_dir'         => '/var/consul',
       'ui_dir'           => '/usr/share/consul',
       'log_level'        => 'INFO',

--- a/puppet/modules/seed_stack/manifests/controller.pp
+++ b/puppet/modules/seed_stack/manifests/controller.pp
@@ -124,6 +124,15 @@ class seed_stack::controller (
     require => Package['unzip']
   }
 
+  $dnsmasq_server = inline_template('<%= @consul_domain.chop() %>') # Remove trailing '.'
+  package { 'dnsmasq': }
+  ~>
+  file { '/etc/dnsmasq.d/consul':
+    content => "cache-size=0\nserver=/$dnsmasq_server/$consul_advertise_addr#8600",
+  }
+  ~>
+  service { 'dnsmasq': }
+
   class { 'consular':
     # ensure => $consular_ensure, # TODO
     consular_args => [

--- a/puppet/modules/seed_stack/manifests/controller.pp
+++ b/puppet/modules/seed_stack/manifests/controller.pp
@@ -1,0 +1,138 @@
+# == Class: seed_stack::controller
+#
+# === Parameters
+#
+# [*controller_addresses*]
+#   A list of IP addresses for all controllers in the cluster.
+#
+# [*address*]
+#   The IP address for the node. All services will be exposed on this address.
+#
+# [*hostname*]
+#   The hostname for the node.
+#
+# [*mesos_ensure*]
+#   The package ensure value for Mesos.
+#
+# [*mesos_cluster*]
+#   The Mesos cluster name.
+#
+# [*marathon_ensure*]
+#   The package ensure value for Marathon.
+#
+# [*consul_version*]
+#   The version of Consul to install.
+#
+# [*consul_client_addr*]
+#   The address to which Consul will bind client interfaces, including the HTTP,
+#   DNS, and RPC servers.
+#
+# [*consul_domain*]
+#   The domain to be served by Consul DNS.
+#
+# [*consul_encrypt*]
+#   The secret key to use for encryption of Consul network traffic.
+#
+# [*consular_ensure*]
+#   The package ensure value for Consular.
+#
+# [*consular_sync_interval*]
+#   The interval in seconds between Consular syncs.
+class seed_stack::controller (
+  # Common
+  $controller_addresses   = ['127.0.0.1'],
+  $address                = '127.0.0.1',
+  $hostname               = 'localhost',
+
+  # Mesos
+  $mesos_ensure           = $seed_stack::params::mesos_ensure,
+  $mesos_cluster          = $seed_stack::params::mesos_cluster,
+
+  # Marathon
+  $marathon_ensure        = $seed_stack::params::marathon_ensure,
+
+  # Consul
+  $consul_version         = $seed_stack::params::consul_version,
+  $consul_client_addr     = $seed_stack::params::consul_client_addr,
+  $consul_domain          = $seed_stack::params::consul_domain,
+  $consul_encrypt         = undef,
+
+  # Consular
+  $consular_ensure        = $seed_stack::params::consular_ensure,
+  $consular_sync_interval = $seed_stack::params::consular_sync_interval,
+) inherits seed_stack::params {
+
+  # Basic parameter validation
+  validate_ip_address($address)
+  validate_ip_address($consul_client_addr)
+  validate_integer($consular_sync_interval)
+  if ! member($controller_addresses, $address) {
+    fail("The address for this node ($address) must be one of the controller addresses ($controller_addresses).")
+  }
+
+  class { 'zookeeper':
+    servers   => $controller_addresses,
+    client_ip => $address
+  }
+
+  $mesos_zk = inline_template('zk://<%= @controller_addresses.map { |c| "#{c}:2181"}.join(",") %>/mesos')
+  class { 'mesos':
+    ensure         => $mesos_ensure,
+    repo           => 'mesosphere',
+    listen_address => $address,
+    zookeeper      => $mesos_zk,
+  }
+
+  class { 'mesos::master':
+    cluster => $mesos_cluster,
+    options => {
+      hostname => $hostname,
+      quorum   => inline_template('<%= (@controller_addresses.size() / 2 + 1).floor() %>'),
+    },
+  }
+
+  $marathon_zk = inline_template('zk://<%= @controller_addresses.map { |c| "#{c}:2181"}.join(",") %>/marathon')
+  class { 'marathon':
+    ensure    => $marathon_ensure,
+    zookeeper => $marathon_zk,
+    master    => $mesos_zk,
+    options   => {
+      hostname         => $hostname,
+      event_subscriber => 'http_callback',
+    },
+  }
+
+  class { 'consul':
+    version => $consul_version,
+    config_hash => {
+      'server'           => true,
+      'bootstrap_expect' => size($controller_addresses),
+      'join'             => delete($controller_addresses, $address),
+      'data_dir'         => '/var/consul',
+      'ui_dir'           => '/usr/share/consul',
+      'log_level'        => 'INFO',
+      'advertise_addr'   => $address,
+      'client_addr'      => $consul_client_addr,
+      'domain'           => $consul_domain,
+      'encrypt'          => $consul_encrypt,
+    },
+    services => {
+      'marathon'        => { port => 8080 },
+      'mesos-master'    => { port => 5050 },
+      'zookeeper'       => { port => 2181 },
+    },
+    require => Package['unzip']
+  }
+
+  class { 'consular':
+    # ensure => $consular_ensure, # TODO
+    consular_args => [
+      "--host=$address",
+      "--sync-interval=$consular_sync_interval",
+      '--purge', # TODO: Make configurable
+      "--registration-id=$hostname",
+      "--consul=http://$address:8500",
+      "--marathon=http://$address:8080",
+    ],
+  }
+}

--- a/puppet/modules/seed_stack/manifests/controller.pp
+++ b/puppet/modules/seed_stack/manifests/controller.pp
@@ -134,7 +134,7 @@ class seed_stack::controller (
   service { 'dnsmasq': }
 
   class { 'consular':
-    # ensure => $consular_ensure, # TODO
+    ensure        => $consular_ensure,
     consular_args => [
       "--host=$address",
       "--sync-interval=$consular_sync_interval",

--- a/puppet/modules/seed_stack/manifests/init.pp
+++ b/puppet/modules/seed_stack/manifests/init.pp
@@ -1,0 +1,5 @@
+# == Class: seed_stack
+#
+class seed_stack inherits seed_stack::params {
+
+}

--- a/puppet/modules/seed_stack/manifests/init.pp
+++ b/puppet/modules/seed_stack/manifests/init.pp
@@ -1,5 +1,6 @@
 # == Class: seed_stack
 #
-class seed_stack inherits seed_stack::params {
+# Use seed_stack::controller or seed_stack::worker
+class seed_stack {
 
 }

--- a/puppet/modules/seed_stack/manifests/params.pp
+++ b/puppet/modules/seed_stack/manifests/params.pp
@@ -1,0 +1,25 @@
+# == Class: seed_stack::params
+#
+class seed_stack::params {
+
+  $docker_ensure            = '1.9.1*'
+
+  $mesos_ensure             = '0.24.1*'
+  $mesos_cluster            = 'seed-stack'
+  $mesos_resources          = {}
+
+  $marathon_ensure          = '0.13.0*'
+  $marathon_default_options = { # TODO
+    'event_subscriber' => 'http_callback' # HTTP callbacks for Consular
+  }
+
+  $consul_version           = '0.6.0'
+  $consul_advertise_addr    = '127.0.0.1'
+  $consul_client_addr       = '0.0.0.0'
+  $consul_domain            = 'consul.'
+
+  $consular_ensure          = '1.2.0*'
+  $consular_sync_interval   = '300'
+
+  $consul_template_version  = '0.12.0'
+}

--- a/puppet/modules/seed_stack/manifests/worker.pp
+++ b/puppet/modules/seed_stack/manifests/worker.pp
@@ -60,7 +60,7 @@ class seed_stack::worker (
 
   # Docker
   $docker_ensure           = $seed_stack::params::docker_ensure,
-) inherits seed_stack {
+) inherits seed_stack::params {
 
   # Basic parameter validation
   validate_ip_address($address)

--- a/puppet/modules/seed_stack/manifests/worker.pp
+++ b/puppet/modules/seed_stack/manifests/worker.pp
@@ -1,0 +1,171 @@
+# == Class: seed_stack::worker
+#
+# === Parameters
+#
+# [*controller_addresses*]
+#   A list of IP addresses for all controllers in the cluster.
+#
+# [*address*]
+#   The IP address for the node. All services will be exposed on this address.
+#
+# [*hostname*]
+#   The hostname for the node.
+#
+# [*controller*]
+#   Whether or not this worker node is also a controller.
+#
+# [*mesos_ensure*]
+#   The package ensure value for Mesos.
+#
+# [*mesos_resources*]
+#   A hash of the available Mesos resources for the node.
+#
+# [*consul_version*]
+#   The version of Consul to install.
+#
+# [*consul_client_addr*]
+#   The address to which Consul will bind client interfaces, including the HTTP,
+#   DNS, and RPC servers. NOTE: Even if *consul_client* is set to false this
+#   parameter must be set to the correct value.
+#
+# [*consul_domain*]
+#   The domain to be served by Consul DNS. NOTE: Even if *consul_client* is set
+#   to false this parameter must be set to the correct value.
+#
+# [*consul_encrypt*]
+#   The secret key to use for encryption of Consul network traffic.
+#
+# [*consul_template_version*]
+#   The version of Consul Template to install.
+#
+# [*docker_ensure*]
+#   The package ensure value for Docker Engine.
+class seed_stack::worker (
+  # Common
+  $controller_addresses    = ['127.0.0.1'],
+  $address                 = '127.0.0.1',
+  $hostname                = 'localhost',
+  $controller              = false,
+
+  # Mesos
+  $mesos_ensure            = $seed_stack::params::mesos_ensure,
+  $mesos_resources         = $seed_stack::params::mesos_resources,
+
+  # Consul
+  $consul_version          = $seed_stack::params::consul_version,
+  $consul_client_addr      = $seed_stack::params::consul_client_addr,
+  $consul_domain           = $seed_stack::params::consul_domain,
+  $consul_encrypt          = undef,
+
+  # Consul Template
+  $consul_template_version = $seed_stack::params::consul_template_version,
+
+  # Docker
+  $docker_ensure           = $seed_stack::params::docker_ensure,
+) inherits seed_stack {
+
+  # Basic parameter validation
+  validate_ip_address($address)
+  validate_bool($controller)
+  validate_hash($mesos_resources)
+  validate_ip_address($consul_client_addr)
+
+  $mesos_zk = inline_template('zk://<%= @controller_addresses.map { |c| "#{c}:2181"}.join(",") %>/mesos')
+  if ! $controller {
+    class { 'mesos':
+      ensure         => $mesos_ensure,
+      repo           => 'mesosphere',
+      listen_address => $address,
+      zookeeper      => $mesos_zk,
+    }
+  }
+
+  class { 'mesos::slave':
+    master    => $mesos_zk,
+    resources => $mesos_resources,
+    options   => {
+      hostname                      => $hostname,
+      containerizers                => 'docker,mesos',
+      executor_registration_timeout => '5mins',
+    },
+  }
+
+  if ! $controller {
+    class { 'consul':
+      version     => $consul_version,
+      config_hash => {
+        'bootstrap_expect' => size($controller_addresses),
+        'join'             => $controller_addresses,
+        'server'           => false,
+        'data_dir'         => '/var/consul',
+        'log_level'        => 'INFO',
+        'advertise_addr'   => $address,
+        'client_addr'      => $consul_client_addr,
+        'domain'           => $consul_domain,
+        'encrypt'          => $consul_encrypt,
+      },
+      services    => {
+        'mesos-slave' => { port => 5051 },
+      },
+    }
+  }
+
+  package { 'nginx-light': }
+  ~>
+  service { 'nginx': }
+
+  # Consul Template to dynamically configure Nginx
+  class { 'consul_template':
+    version          => $consul_template_version,
+    config_dir       => '/etc/consul-template',
+    user             => 'root',
+    group            => 'root',
+    consul_host      => $address,
+    consul_port      => 8500,
+    consul_retry     => '10s',
+    # For some reason, consul-template doesn't like this option.
+    # consul_max_stale => '10m',
+    log_level        => 'warn',
+    require          => Package['unzip']
+  }
+
+  # Configure Nginx to load-balance across uptream services
+  file { '/etc/consul-template/nginx-upstreams.ctmpl':
+    source => 'puppet:///modules/consular/nginx-upstreams.ctmpl',
+  }
+  ~>
+  consul_template::watch { 'nginx-upstreams':
+    source      => '/etc/consul-template/nginx-upstreams.ctmpl',
+    destination => '/etc/nginx/sites-enabled/seed-upstreams.conf',
+    command     => '/etc/init.d/nginx reload',
+    require     => Service['nginx'],
+  }
+
+  # Configure Nginx to route to upstream services
+  file { '/etc/consul-template/nginx-services.ctmpl':
+    source => 'puppet:///modules/consular/nginx-services.ctmpl',
+  }
+  ~>
+  consul_template::watch { 'nginx-services':
+    source      => '/etc/consul-template/nginx-services.ctmpl',
+    destination => '/etc/nginx/sites-enabled/seed-services.conf',
+    command     => '/etc/init.d/nginx reload',
+    require     => Service['nginx'],
+  }
+
+  # dnsmasq to serve DNS requests, sending requests in the Consul domain to Consul
+  $dnsmasq_server = inline_template('<%= @consul_domain.chop() %>') # Remove trailing '.'
+  package { 'dnsmasq': }
+  ~>
+  file { '/etc/dnsmasq.d/consul':
+    content => "cache-size=0\nserver=/$dnsmasq_server/$consul_advertise_addr#8600",
+  }
+  ~>
+  service { 'dnsmasq': }
+
+  # Docker, using the host for DNS
+  class { 'docker':
+    ensure => $docker_ensure,
+    dns    => $ipaddress_docker0,
+  }
+}

--- a/puppet/modules/seed_stack/manifests/worker.pp
+++ b/puppet/modules/seed_stack/manifests/worker.pp
@@ -25,12 +25,10 @@
 #
 # [*consul_client_addr*]
 #   The address to which Consul will bind client interfaces, including the HTTP,
-#   DNS, and RPC servers. NOTE: Even if *consul_client* is set to false this
-#   parameter must be set to the correct value.
+#   DNS, and RPC servers.
 #
 # [*consul_domain*]
-#   The domain to be served by Consul DNS. NOTE: Even if *consul_client* is set
-#   to false this parameter must be set to the correct value.
+#   The domain to be served by Consul DNS.
 #
 # [*consul_encrypt*]
 #   The secret key to use for encryption of Consul network traffic.
@@ -154,14 +152,16 @@ class seed_stack::worker (
   }
 
   # dnsmasq to serve DNS requests, sending requests in the Consul domain to Consul
-  $dnsmasq_server = inline_template('<%= @consul_domain.chop() %>') # Remove trailing '.'
-  package { 'dnsmasq': }
-  ~>
-  file { '/etc/dnsmasq.d/consul':
-    content => "cache-size=0\nserver=/$dnsmasq_server/$consul_advertise_addr#8600",
+  if ! controller {
+    $dnsmasq_server = inline_template('<%= @consul_domain.chop() %>') # Remove trailing '.'
+    package { 'dnsmasq': }
+    ~>
+    file { '/etc/dnsmasq.d/consul':
+      content => "cache-size=0\nserver=/$dnsmasq_server/$consul_advertise_addr#8600",
+    }
+    ~>
+    service { 'dnsmasq': }
   }
-  ~>
-  service { 'dnsmasq': }
 
   # Docker, using the host for DNS
   class { 'docker':

--- a/puppet/modules/seed_stack/manifests/worker.pp
+++ b/puppet/modules/seed_stack/manifests/worker.pp
@@ -93,7 +93,7 @@ class seed_stack::worker (
       version     => $consul_version,
       config_hash => {
         'bootstrap_expect' => size($controller_addresses),
-        'join'             => $controller_addresses,
+        'retry_join'       => $controller_addresses,
         'server'           => false,
         'data_dir'         => '/var/consul',
         'log_level'        => 'INFO',


### PR DESCRIPTION
A new module that wraps up the concepts of "controller" and "worker".

A controller has the following:
- Zookeeper
- Mesos master
- Marathon
- Consul server
- Dnsmasq for Consul DNS
- Consular

A worker has:
- Mesos slave
- Consul client
- Docker
- Dnsmasq for Consul DNS
- Nginx
- Consul Template
- Templates to configure nginx for service routing

The intention is for this to eventually be a standalone Puppet module that is published on Puppet Forge. For now, this is an easy place to get started. We need to have published Puppet modules for Marathon and Consular before this can be a standalone module.

Other things to do:
- Nginx webserver/loadbalancer (a-la Unicore)
- Docker registry stuff (not sure where this should be run)
