### PR TITLE
Use a bootstrap VM with a puppet server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,8 @@ Install Vagrant_ and then::
 
     $ git clone git://github.com/praekelt/seed-stack.git
     $ cd seed-stack
-    $ vagrant up standalone
+    $ vagrant plugin install vagrant-hostmanager
+    $ vagrant up standalone boot
 
 This will result in a stack running:
 
@@ -19,39 +20,57 @@ This will result in a stack running:
 8. Consular_
 9. Consul-Template_
 10. Nginx_
+11. Mission Control
 
-All of this is installed and configured using Puppet_. For more information, see the `Puppet README`_.
+All of this is installed and configured using Puppet_. For more information,
+see the `Puppet README`_.
 
 The available VMs defined in the Vagrantfile are as follows:
-- ``standalone`` - a Seed Stack combination controller/worker with a Docker Registry and load-balancer
+- ``standalone`` - a Seed Stack combination controller/worker with a Docker
+  Registry and load-balancer
 - ``controller`` - a Seed Stack controller with a load-balancer
 - ``worker`` - a Seed Stack worker with a Docker Registry
+- ``boot`` - a bootstrap machine Puppet server used for provisioning other VMs
+  (*must* be provisioned last)
 
-You can run either the standalone VM or the controller and worker VMs but not both as their forwarded ports will conflict.
 
-Once running launch the sample ``python-server`` application::
+You can probably run the standalone VM and controller/worker VMs at the same
+time, but there shouldn't be any need to do so.
+
+Once running, you can manually launch the sample ``python-server`` application
+through marathon::
 
     $ curl -XPOST \
         -d @python-server.json \
         -H 'Content-Type: application/json' \
-        http://localhost:8080/v2/apps
+        http://standalone.seed-stack.local:8080/v2/apps
 
-Then you should be able to use the application in your web browser at http://python-server.127.0.0.1.xip.io:8000
+You can watch the deployment progress in the Marathon web UI (see below).
+Deploying for the first time on a newly provisioned VM may take a while because
+it has to download the docker image first.
 
-The following services have port forwarding configured and are available
-on the host:
+Then you should be able to use the application in your web browser at
+http://python-server.192.168.55.9.xip.io
+
+(For the controller/worker setup, use ``controller.seed-stack.local`` and
+``192.168.55.11`` instead.)
+
+The following services are available on the standalone or controller VM:
 
 Marathon
-    http://localhost:8080
+    http://standalone.seed-stack.local:8080
 
 Mesos
-    http://localhost:5050
+    http://standalone.seed-stack.local:5050
 
 Consul
-    http://localhost:8500/ui/
+    http://standalone.seed-stack.local:8500/ui/
 
-Nginx
-    http://localhost:8000
+Mission Control (log in with admin/pass)
+    http://mc2.infr.standalone.seed-stack.local
+
+In order to access apps running in Mission Control, you may need to add
+``/etc/hosts`` entries for their domains.
 
 
 .. _Vagrant: http://www.vagrantup.com
@@ -66,3 +85,10 @@ Nginx
 .. _Zookeeper: https://zookeeper.apache.org/
 .. _Puppet: http://docs.puppetlabs.com/puppet/3/reference/
 .. _Puppet README: puppet/README.md
+
+
+Acknowledgements
+----------------
+
+The vagrant plugin used for provisioning with a bootstrap machine is heavily
+inspired by the one in https://github.com/dcos/dcos-vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,13 +17,15 @@ MACHINES = {
   "standalone" => {
     :ip => "192.168.55.9",
     :machine_type => "controller",  # It's a worker as well.
-    :memory => "1536"
+    :aliases => ["mc2.infr.standalone.seed-stack.local"],
+    :memory => "1536",
   },
 
   # Separate controller and worker.
   "controller" => {
     :ip => "192.168.55.11",
     :machine_type => "controller",
+    :aliases => ["mc2.infr.controller.seed-stack.local"],
   },
   "worker" => {
     :ip => "192.168.55.21",
@@ -56,6 +58,7 @@ Vagrant.configure(2) do |config|
 
       machine.vm.hostname = "#{name}.#{DOMAIN}"
       machine.vm.network "private_network", ip: "#{mcfg[:ip]}"
+      machine.hostmanager.aliases = mcfg.fetch(:aliases, [])
 
       machine.vm.provider "virtualbox" do |vb|
         vb.memory = mcfg.fetch(:memory, "1024")

--- a/lib/vagrant-seed.rb
+++ b/lib/vagrant-seed.rb
@@ -1,0 +1,9 @@
+require_relative 'vagrant-seed/plugin'
+
+module VagrantPlugins
+  module Seed
+    def self.source_root
+      @source_root ||= Pathname.new(File.expand_path('../../', __FILE__))
+    end
+  end
+end

--- a/lib/vagrant-seed/plugin.rb
+++ b/lib/vagrant-seed/plugin.rb
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Seed installer plugin, mostly borrowed from vagrant-dcos.
+
+module VagrantPlugins
+  module Seed
+    VERSION = '0.1'
+
+    class Plugin < Vagrant.plugin(2)
+      name "seed"
+
+      config :seed_install, :provisioner do
+        require_relative 'provisioner_config'
+        ProvisionerConfig
+      end
+
+      provisioner :seed_install do
+        require_relative 'provisioner'
+        Provisioner
+      end
+    end
+
+  end
+end

--- a/lib/vagrant-seed/provisioner.rb
+++ b/lib/vagrant-seed/provisioner.rb
@@ -1,0 +1,64 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# require_relative 'executor'
+# require 'thread'
+# require 'yaml'
+
+# This is mostly borrowed from vagrant-dcos.
+
+module VagrantPlugins
+  module Seed
+    class Provisioner < Vagrant.plugin(2, :provisioner)
+
+      def configure(root_config)
+      end
+
+      def provision
+        install_machines_of_type("controller")
+        install_machines_of_type("worker")
+      end
+
+      protected
+
+      # execute remote command as root
+      # print command, stdout, and stderr (indented)
+      def remote_sudo(machine, command)
+        machine.ui.output("sudo: #{command}")
+        machine.communicate.sudo(command) do |type, data|
+          unless data == "\n"
+            output = '      ' + data.chomp
+            case type
+            when :stdout
+              machine.ui.output(output)
+            when :stderr
+              machine.ui.error(output)
+            end
+          end
+        end
+      end
+
+      def install_machine(machine)
+        @machine.ui.success "Installing #{machine.name}..."
+        script = [
+          'puppet agent --server boot.seed-stack.local --waitforcert 2 --test',
+          'puppetcode=$?',
+          'case $puppetcode in',
+          '  0|2) exit 0;;',
+          '  *) exit $puppetcode;;',
+          'esac',
+        ].join("\n")
+        remote_sudo(machine, "sh -c '#{script}'")
+      end
+
+      def install_machines_of_type(machine_type)
+        @machine.env.active_machines.each do |name, provider|
+          if @config.machines[name.to_s][:machine_type] == machine_type
+            install_machine(@machine.env.machine(name, provider))
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/vagrant-seed/provisioner_config.rb
+++ b/lib/vagrant-seed/provisioner_config.rb
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+module VagrantPlugins
+  module Seed
+    class ProvisionerConfig < Vagrant.plugin(2, :config)
+      attr_accessor :machines
+      attr_accessor :max_install_threads
+
+      def initialize()
+        super
+        @machines = UNSET_VALUE
+        @max_install_threads = UNSET_VALUE
+      end
+
+      def finalize!
+        # defaults after merging
+        @machines = {} if @machine_types == UNSET_VALUE
+        @max_install_threads = 4 if @max_install_threads == UNSET_VALUE
+      end
+
+      # The validation method is given a machine object, since validation is done for each machine that Vagrant is managing
+      def validate(machine)
+        errors = _detected_errors
+
+        unless @max_install_threads > 0
+          errors << "Invalid config: 'max_install_threads' must be greater than zero"
+        end
+
+        if @machines.nil? || @machines.empty? || @machines == UNSET_VALUE
+            errors << "Invalid config: 'machines' is required"
+        end
+
+        return { "seed_install" => errors }
+      end
+    end
+  end
+end

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -1,8 +1,8 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    KyleAnderson-consul (1.0.5)
-      nanliu-staging (< 2.0.0, >= 0.4.0)
+    KyleAnderson-consul (1.0.8)
+      puppet-archive (< 1.0.0, >= 0.5.0)
       puppetlabs-stdlib (< 5.0.0, >= 4.6.0)
     camptocamp-openssl (1.6.1)
       puppetlabs-stdlib (< 5.0.0, >= 2.0.0)
@@ -16,7 +16,7 @@ FORGE
       puppetlabs-apt (<= 3.0.0, >= 1.8.0)
       puppetlabs-stdlib (>= 4.1.0)
       stahnma-epel (>= 0.0.6)
-    gdhbashton-consul_template (0.2.4)
+    gdhbashton-consul_template (0.2.5)
       nanliu-staging (>= 0.4.0)
       puppetlabs-concat (>= 1.1.0)
       puppetlabs-stdlib (>= 1.0.0)
@@ -29,7 +29,7 @@ FORGE
       deric-mesos (>= 0.6.5)
       puppetlabs-apt (>= 2.1.0)
       puppetlabs-stdlib (>= 4.2.0)
-    praekeltfoundation-seed_stack (0.9.2)
+    praekeltfoundation-seed_stack (0.9.3)
       KyleAnderson-consul (>= 1.0.4)
       deric-mesos (< 0.9.0, >= 0.8.0)
       deric-zookeeper (< 0.6.0, >= 0.5.1)
@@ -45,10 +45,14 @@ FORGE
     praekeltfoundation-xylem (0.2.0)
       puppetlabs-apt (>= 0)
       puppetlabs-concat (>= 0)
+    puppet-archive (0.5.1)
+      puppetlabs-pe_gem (>= 0.0.1)
+      puppetlabs-stdlib (>= 2.2.1)
     puppetlabs-apt (2.2.2)
       puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
     puppetlabs-concat (2.1.0)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
+    puppetlabs-pe_gem (0.2.0)
     puppetlabs-stdlib (4.11.0)
     richardc-datacat (0.6.2)
     stahnma-epel (1.2.2)
@@ -56,5 +60,5 @@ FORGE
 
 DEPENDENCIES
   camptocamp-openssl (>= 1.5.0)
-  praekeltfoundation-seed_stack (< 0.10.0, >= 0.9.2)
+  praekeltfoundation-seed_stack (< 0.10.0, >= 0.9.3)
 

--- a/puppet/environments/seed_stack/manifests/site.pp
+++ b/puppet/environments/seed_stack/manifests/site.pp
@@ -46,21 +46,27 @@ node 'standalone.seed-stack.local' {
 # Keep track of node IP addresses across the cluster
 # FIXME: A better, more automatic way to do this
 class seed_stack_cluster {
-  $controller_ip = '192.168.0.2'
-  $worker_ip = '192.168.0.3'
+  $controller_ip = '192.168.55.11'
+  $worker_ip = '192.168.55.21'
 
-  host { 'controller.seed-stack.local':
-    ip           => $controller_ip,
-    host_aliases => ['controller'],
-  }
-  host { 'worker.seed-stack.local':
-    ip           => $worker_ip,
-    host_aliases => ['worker'],
-  }
+  # The hostmanager vagrant plugin manages the hosts entries for us.
+
+  # host { 'controller.seed-stack.local':
+  #   ip           => $controller_ip,
+  #   host_aliases => ['controller'],
+  # }
+  # host { 'worker.seed-stack.local':
+  #   ip           => $worker_ip,
+  #   host_aliases => ['worker'],
+  # }
 }
 
 node 'controller.seed-stack.local' {
   include seed_stack_cluster
+
+  file { ['/data/', '/data/brick1/', '/data/brick2']:
+    ensure  => 'directory',
+  }
 
   package { 'redis-server': ensure => 'installed' }
   ->

--- a/puppet/environments/seed_stack/manifests/site.pp
+++ b/puppet/environments/seed_stack/manifests/site.pp
@@ -46,19 +46,10 @@ node 'standalone.seed-stack.local' {
 # Keep track of node IP addresses across the cluster
 # FIXME: A better, more automatic way to do this
 class seed_stack_cluster {
+  # The hostmanager vagrant plugin manages the hosts entries for us, but
+  # various things still need the IPs. Bleh.
   $controller_ip = '192.168.55.11'
   $worker_ip = '192.168.55.21'
-
-  # The hostmanager vagrant plugin manages the hosts entries for us.
-
-  # host { 'controller.seed-stack.local':
-  #   ip           => $controller_ip,
-  #   host_aliases => ['controller'],
-  # }
-  # host { 'worker.seed-stack.local':
-  #   ip           => $worker_ip,
-  #   host_aliases => ['worker'],
-  # }
 }
 
 node 'controller.seed-stack.local' {

--- a/puppet/puppetmaster-bootstrap.sh
+++ b/puppet/puppetmaster-bootstrap.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+PUPDIR=/etc/puppetlabs/code
+ENVDIR=${PUPDIR}/environments/production
+
+if dpkg-query -l puppetserver > /dev/null; then
+    echo "Found puppetserver package."
+else
+    echo "Installing puppetserver package and related things."
+    apt-get install -qy --no-install-recommends \
+            puppetserver bundler git ruby-dev
+fi
+
+# Copy our puppet configs over.
+cp -a /vagrant/puppet/environments/seed_stack/* ${ENVDIR}/
+
+# This is a bit expensive, so only do it if the server isn't already running.
+if service puppetserver status > /dev/null; then
+    echo "Found running puppetserver, not configuring or installing modules."
+else
+    echo "Configuring puppetserver and installing modules."
+
+    # Install puppet modules.
+    cd /vagrant/puppet
+    bundle install --without test
+    bundle exec librarian-puppet install --verbose --path=${ENVDIR}/modules
+
+    # We're a little VM, no need for gigs of reserved memory.
+    sed -i \
+        -e 's/-Xm\([sx]\)\w\+/-Xm\1192m/g' \
+        /etc/default/puppetserver
+
+    echo '*.seed-stack.local' > /etc/puppetlabs/puppet/autosign.conf
+
+    service puppetserver start
+fi
+
+# Get our hands on the key to all the machines.
+cd $HOME
+cp /vagrant/.vagrant/dcos/private_key_vagrant ssh_key
+chmod 600 ssh_key

--- a/puppet/puppetmaster-bootstrap.sh
+++ b/puppet/puppetmaster-bootstrap.sh
@@ -34,8 +34,3 @@ else
 
     service puppetserver start
 fi
-
-# Get our hands on the key to all the machines.
-cd $HOME
-cp /vagrant/.vagrant/dcos/private_key_vagrant ssh_key
-chmod 600 ssh_key

--- a/python-server.json
+++ b/python-server.json
@@ -4,7 +4,7 @@
   "cpus": 0.5,
   "mem": 32.0,
   "labels": {
-    "domain": "python-server.127.0.0.1.xip.io",
+    "domain": "python-server.192.168.55.11.xip.io python-server.192.168.55.9.xip.io",
     "country": "South Africa",
     "project_type": "foo"
   },


### PR DESCRIPTION
We keep running into limitations on what we can do with each machine being provisioned independently. The DC/OS vagrant setup uses a "bootstrap" VM that manages installation and such, with a vagrant plugin to drive the provisioning of the other machines from it. We should do that here, too.
